### PR TITLE
Accept images as file bytes instead of base64

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,9 @@ The service's expects json in the following format:
 
 ```
 {
-    'image': '63469ef70377ee9a23b7b8ec5'
+    'image': '<image byte content>'
 }
 ```
-
-where the image is a base 64 encoded image.
 
 Data will be returned in the following format:
 

--- a/app/api.py
+++ b/app/api.py
@@ -1,26 +1,20 @@
 from flask import Flask, request, jsonify
-import pytesseract
 from PIL import Image
-from io import BytesIO
-import base64
-
+import pytesseract
 
 app = Flask(__name__)
 
 
 @app.route('/', methods=['POST'])
 def index():
-    request_json = request.get_json(force=True)
-    image_string = request_json.get('image')
-
-    if not image_string:
+    if 'image' not in request.files:
         return jsonify(
             error={
                 'image': 'This field is required.'
             }
         ), 400
 
-    image = Image.open(BytesIO(base64.urlsafe_b64decode(image_string)))
+    image = Image.open(request.files['image'])
 
     image_text = pytesseract.image_to_string(
         image,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,80 +1,69 @@
 from unittest import TestCase
 from app import api
-import json
 
 
 class ApiTestCase(TestCase):
 
     def setUp(self):
         import os
-        import base64
 
         self.client = api.app.test_client()
 
         test_directory = os.path.dirname(os.path.abspath(__file__))
 
-        image_path = os.path.join(test_directory, 'image.png')
-
-        with open(image_path, 'rb') as image_file:
-            self.base64_image = base64.b64encode(image_file.read()).decode()
+        self.image_path = os.path.join(test_directory, 'image.png')
 
     def test_data_missing(self):
         """
         Test that an error is returned if the request body is empty.
         """
-        response = self.client.post(
-            '/',
-            content_type='application/json'
-        )
+        response = self.client.post('/')
 
         self.assertEqual(response.status_code, 400)
+
+        self.assertIn('error', response.json)
+        self.assertIn('image', response.json['error'])
+        self.assertIn(
+            'This field is required.',
+            response.json['error']['image']
+        )
 
     def test_image_missing(self):
         """
         Test that the 'image' value is missing.
         """
-        response = self.client.post(
-            '/',
-            data=json.dumps({})
-        )
+        response = self.client.post('/', data={})
 
         self.assertEqual(response.status_code, 400)
 
-        response_json = json.loads(response.data)
-
-        self.assertIn('error', response_json)
-        self.assertIn('image', response_json['error'])
+        self.assertIn('error', response.json)
+        self.assertIn('image', response.json['error'])
         self.assertIn(
             'This field is required.',
-            response_json['error']['image']
+            response.json['error']['image']
         )
 
     def test_post_image(self):
         """
-        Test that the 'image' value is missing.
+        Test posting an image.
         """
-        response = self.client.post(
-            '/',
-            data=json.dumps({
-                'image': self.base64_image
-            })
-        )
+        response = self.client.post('/', data={
+            'image': open(self.image_path, 'rb')
+        })
 
-        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.status_code, 200)
 
-        response_json = json.loads(response.data)
-
-        self.assertIn('text', response_json)
+        self.assertIn('text', response.json)
 
         self.assertIn(
             'woke up this morning',
-            response_json['text']
+            response.json['text']
         )
         self.assertIn(
             'received an invoice from my Google Fi',
-            response_json['text']
+            response.json['text']
         )
         self.assertIn(
             'and headed off to work, listening to',
-            response_json['text']
+            response.json['text']
         )


### PR DESCRIPTION
This simplifies the heck out of how the server accepts file content from requests. Sending the image as a bytes-like object is also much more efficient than sending a base64 encoded image.